### PR TITLE
Add variance of time and position variables

### DIFF
--- a/straxen/plugins/veto_events.py
+++ b/straxen/plugins/veto_events.py
@@ -130,8 +130,6 @@ def compute_nveto_event_properties(events, contained_hitlets, start_channel=2000
                 e['center_time_spread'] = np.sqrt(np.sum(w*np.power(t-e['center_time'],2))/np.sum(w))
             else:
                 e['center_time_spread'] = np.inf
-        else:
-            e['center_time'] = np.nan
 
         # Compute per channel properties:
         for h in hitlets:

--- a/straxen/plugins/veto_events.py
+++ b/straxen/plugins/veto_events.py
@@ -100,6 +100,7 @@ def veto_event_dtype(name_event_number='event_number_nv', n_pmts=120):
               (('Last hitlet endtime in event [ns].', 'last_hitlet_endtime'), np.int64),
               (('Total area of all hitlets in event [pe]', 'area'), np.float32),
               (('Total number of hitlets in events', 'n_hits'), np.int32),
+              (('Total number of contributed channels', 'n_contributed_pmt'), np.int32),
               (('Area in event per channel [pe]', 'area_per_channel'), np.float32, n_pmts),
               (('Area weighted mean time of the event relative to the event start [ns]',
                 'center_time'), np.float32),
@@ -130,6 +131,7 @@ def compute_nveto_event_properties(events, contained_hitlets, pmt_pos, start_cha
         event_area = np.sum(hitlets['area'])
         e['area'] = event_area
         e['n_hits'] = len(hitlets)
+        e['n_contributed_pmt'] = len(np.unique(hitlets['channel']))
 
         t = hitlets['time'] - hitlets[0]['time']
         if event_area:


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
I would like to add some parameters in `events_nv`.
In particular, time spreads of hits and positions.
These are not directly useful for our analysis soon, but useful for comparison of our simulator.

**Can you briefly describe how it works?**
Straight-forward implementation of variances.

**Can you give a minimal working example (or illustrate with a figure)?**
This is available note.
https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:mzks:nveto_event_params_test

** For Daniel
I couldn't find your update of `nVETOEventPositions`, thus I developed them. I noticed these update when my push failures...
These are slightly/much overlapped, could you please discuss about that with me?
